### PR TITLE
systemd: add Install section

### DIFF
--- a/node-startup-controller/node-startup-controller.service.in
+++ b/node-startup-controller/node-startup-controller.service.in
@@ -2,3 +2,6 @@
 Type = notify
 ExecStart = @libdir@/node-startup-controller-@NODE_STARTUP_CONTROLLER_VERSION_API@/node-startup-controller
 WatchdogSec = 5
+
+[Install]
+WantedBy=focussed.target


### PR DESCRIPTION
By adding this the standard "systemctl enable node-startup-controller" can be used to enable the service.