### PR TITLE
Release 1.0.3

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,13 @@
-x.y.z
+1.0.3
+=====
+* Add autogen script
+* Fix bug in node_startup_controller_application_get_property()
+* Improve documentation
+* Fix error in systemd service
+* License updates, and added SPDX license identifiers
+* Added [Install] section to systemd service
+
+1.0.2
 =====
 * Adjust D-Bus interface definitions to match the Node State Manager.
 * Fix starting through systemd if the LUC cannot be read from disk.

--- a/NEWS
+++ b/NEWS
@@ -1,9 +1,12 @@
 x.y.z
 =====
-* Make systemd respond to "READY" notifications from the NSC (GT-2212)
 * Adjust D-Bus interface definitions to match the Node State Manager.
 * Fix starting through systemd if the LUC cannot be read from disk.
 * Changed documentation license to CC-BY-SA 4.0
+
+1.0.1
+=====
+* Make systemd respond to "READY" notifications from the NSC (GT-2212)
 
 1.0.0
 =====

--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@ dnl ***************************
 m4_define([node_startup_controller_version_api_major], [1])
 m4_define([node_startup_controller_version_major], [1])
 m4_define([node_startup_controller_version_minor], [0])
-m4_define([node_startup_controller_version_micro], [1])
+m4_define([node_startup_controller_version_micro], [3])
 m4_define([node_startup_controller_version], [node_startup_controller_version_major().node_startup_controller_version_minor().node_startup_controller_version_micro()])
 
 dnl ***************************


### PR DESCRIPTION
Since last MR went so smoothly I figured I might as well do one for making a 1.0.3 release as well. If you merge this it would be great if you could also add a tag "node-startup-controller-1.0.3".