### PR TITLE
doc: move xml tag to top line of file

### DIFF
--- a/docs/reference/node-startup-controller/about.xml
+++ b/docs/reference/node-startup-controller/about.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 SPDX license identifier: CC-BY-SA-4.0
 
@@ -7,7 +8,6 @@ This work is licensed under a Creative Commons Attribution-ShareAlike
 
 4.0 International License. 
 -->
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                           "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 ]>

--- a/docs/reference/node-startup-controller/building.xml
+++ b/docs/reference/node-startup-controller/building.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 SPDX license identifier: CC-BY-SA-4.0
 
@@ -7,7 +8,6 @@ This work is licensed under a Creative Commons Attribution-ShareAlike
 
 4.0 International License. 
 -->
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                           "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 ]>

--- a/docs/reference/node-startup-controller/functional-scope.xml
+++ b/docs/reference/node-startup-controller/functional-scope.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 SPDX license identifier: CC-BY-SA-4.0
 
@@ -7,7 +8,6 @@ This work is licensed under a Creative Commons Attribution-ShareAlike
 
 4.0 International License. 
 -->
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                           "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 ]>

--- a/docs/reference/node-startup-controller/legacy-app-handler.xml
+++ b/docs/reference/node-startup-controller/legacy-app-handler.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 SPDX license identifier: CC-BY-SA-4.0
 
@@ -7,7 +8,6 @@ This work is licensed under a Creative Commons Attribution-ShareAlike
 
 4.0 International License. 
 -->
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                           "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 ]>

--- a/docs/reference/node-startup-controller/node-startup-controller-docs.xml
+++ b/docs/reference/node-startup-controller/node-startup-controller-docs.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <!--
 SPDX license identifier: CC-BY-SA-4.0
 
@@ -7,7 +8,6 @@ This work is licensed under a Creative Commons Attribution-ShareAlike
 
 4.0 International License. 
 -->
-<?xml version="1.0"?>
 <!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.3//EN"
                       "http://www.oasis-open.org/docbook/xml/4.3/docbookx.dtd"
 [

--- a/docs/reference/node-startup-controller/public-interfaces.xml
+++ b/docs/reference/node-startup-controller/public-interfaces.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 SPDX license identifier: CC-BY-SA-4.0
 
@@ -7,7 +8,6 @@ This work is licensed under a Creative Commons Attribution-ShareAlike
 
 4.0 International License. 
 -->
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                           "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 ]>

--- a/docs/reference/node-startup-controller/software-architecture.xml
+++ b/docs/reference/node-startup-controller/software-architecture.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 SPDX license identifier: CC-BY-SA-4.0
 
@@ -7,7 +8,6 @@ This work is licensed under a Creative Commons Attribution-ShareAlike
 
 4.0 International License. 
 -->
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                           "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 ]>

--- a/docs/reference/node-startup-controller/test-legacy-app-handling.xml
+++ b/docs/reference/node-startup-controller/test-legacy-app-handling.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 SPDX license identifier: CC-BY-SA-4.0
 
@@ -7,7 +8,6 @@ This work is licensed under a Creative Commons Attribution-ShareAlike
 
 4.0 International License. 
 -->
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                           "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 ]>

--- a/docs/reference/node-startup-controller/test-luc-management.xml
+++ b/docs/reference/node-startup-controller/test-luc-management.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 SPDX license identifier: CC-BY-SA-4.0
 
@@ -7,7 +8,6 @@ This work is licensed under a Creative Commons Attribution-ShareAlike
 
 4.0 International License. 
 -->
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                           "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 ]>

--- a/docs/reference/node-startup-controller/test-nsm-dummy.xml
+++ b/docs/reference/node-startup-controller/test-nsm-dummy.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 SPDX license identifier: CC-BY-SA-4.0
 
@@ -7,7 +8,6 @@ This work is licensed under a Creative Commons Attribution-ShareAlike
 
 4.0 International License. 
 -->
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                           "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 ]>

--- a/docs/reference/node-startup-controller/test-target-startup-monitoring.xml
+++ b/docs/reference/node-startup-controller/test-target-startup-monitoring.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 SPDX license identifier: CC-BY-SA-4.0
 
@@ -7,7 +8,6 @@ This work is licensed under a Creative Commons Attribution-ShareAlike
 
 4.0 International License. 
 -->
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                           "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 ]>

--- a/docs/reference/node-startup-controller/test-test-environment-setup.xml
+++ b/docs/reference/node-startup-controller/test-test-environment-setup.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
 SPDX license identifier: CC-BY-SA-4.0
 
@@ -7,7 +8,6 @@ This work is licensed under a Creative Commons Attribution-ShareAlike
 
 4.0 International License. 
 -->
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.1.2//EN"
                           "http://www.oasis-open.org/docbook/xml/4.1.2/docbookx.dtd" [
 ]>


### PR DESCRIPTION
There are errors with multiple docbook xml file while
make documentation.

../node-startup-controller-docs.xml:10: parser error :
XML declaration allowed only at the start of the document

Signed-off-by: Phong Tran <tranmanphong@gmail.com>