### PR TITLE
Makefile.am: Declare project as foreign

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,3 +23,5 @@ dist-hook: ChangeLog
 DISTCHECK_CONFIGURE_FLAGS =						\
 	--enable-gtk-doc						\
 	--enable-debug=no
+
+AUTOMAKE_OPTIONS = foreign


### PR DESCRIPTION
The README file is renamed to README.md which broke the
generation of Makefile.in via autogen.sh script. Declaring
the project as "foreign" will allow not to conform to GNU
standards (e.g. missing README file).

Signed-off-by: Vishal Thanki <vishalthanki@gmail.com>